### PR TITLE
Serialize tests that modify environment variables

### DIFF
--- a/crates/goose/src/tracing/langfuse_layer.rs
+++ b/crates/goose/src/tracing/langfuse_layer.rs
@@ -187,6 +187,7 @@ mod tests {
     use super::*;
     use serde_json::json;
     use std::collections::HashMap;
+    use serial_test::serial;
     use tokio::sync::Mutex;
     use tracing::dispatcher;
     use wiremock::matchers::{method, path};
@@ -389,6 +390,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_create_langfuse_observer() {
         let fixture = TestFixture::new().await.with_mock_server().await;
 

--- a/crates/goose/tests/providers.rs
+++ b/crates/goose/tests/providers.rs
@@ -8,6 +8,7 @@ use goose::providers::{
 };
 use mcp_core::content::Content;
 use mcp_core::tool::Tool;
+use serial_test::serial;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::Mutex;
@@ -352,6 +353,7 @@ where
 }
 
 #[tokio::test]
+#[serial]
 async fn test_openai_provider() -> Result<()> {
     test_provider(
         "OpenAI",
@@ -363,6 +365,7 @@ async fn test_openai_provider() -> Result<()> {
 }
 
 #[tokio::test]
+#[serial]
 async fn test_azure_provider() -> Result<()> {
     test_provider(
         "Azure",
@@ -378,6 +381,7 @@ async fn test_azure_provider() -> Result<()> {
 }
 
 #[tokio::test]
+#[serial]
 async fn test_bedrock_provider_long_term_credentials() -> Result<()> {
     test_provider(
         "Bedrock",
@@ -389,6 +393,7 @@ async fn test_bedrock_provider_long_term_credentials() -> Result<()> {
 }
 
 #[tokio::test]
+#[serial]
 async fn test_bedrock_provider_aws_profile_credentials() -> Result<()> {
     let env_mods = HashMap::from_iter([
         // Ensure to unset long-term credentials to use AWS Profile provider
@@ -406,6 +411,7 @@ async fn test_bedrock_provider_aws_profile_credentials() -> Result<()> {
 }
 
 #[tokio::test]
+#[serial]
 async fn test_databricks_provider() -> Result<()> {
     test_provider(
         "Databricks",
@@ -417,6 +423,7 @@ async fn test_databricks_provider() -> Result<()> {
 }
 
 #[tokio::test]
+#[serial]
 async fn test_databricks_provider_oauth() -> Result<()> {
     let mut env_mods = HashMap::new();
     env_mods.insert("DATABRICKS_TOKEN", None);
@@ -431,6 +438,7 @@ async fn test_databricks_provider_oauth() -> Result<()> {
 }
 
 #[tokio::test]
+#[serial]
 async fn test_ollama_provider() -> Result<()> {
     test_provider(
         "Ollama",
@@ -442,11 +450,13 @@ async fn test_ollama_provider() -> Result<()> {
 }
 
 #[tokio::test]
+#[serial]
 async fn test_groq_provider() -> Result<()> {
     test_provider("Groq", &["GROQ_API_KEY"], None, groq::GroqProvider::default).await
 }
 
 #[tokio::test]
+#[serial]
 async fn test_anthropic_provider() -> Result<()> {
     test_provider(
         "Anthropic",
@@ -458,6 +468,7 @@ async fn test_anthropic_provider() -> Result<()> {
 }
 
 #[tokio::test]
+#[serial]
 async fn test_openrouter_provider() -> Result<()> {
     test_provider(
         "OpenRouter",
@@ -469,6 +480,7 @@ async fn test_openrouter_provider() -> Result<()> {
 }
 
 #[tokio::test]
+#[serial]
 async fn test_google_provider() -> Result<()> {
     test_provider(
         "Google",


### PR DESCRIPTION
## Summary
- add `serial_test` import for provider tests and mark each provider test `#[serial]`
- mark `test_create_langfuse_observer` as serial to avoid env races

## Testing
- `cargo fmt` *(fails: rustfmt missing)*
- `cargo test --workspace --lib --tests` *(fails: could not fetch crates)*