### PR TITLE
Fix SessionConfig initialization

### DIFF
--- a/crates/goose-api/src/handlers.rs
+++ b/crates/goose-api/src/handlers.rs
@@ -119,6 +119,7 @@ pub async fn start_session_handler(
             Some(SessionConfig {
                 id: Identifier::Name(session_name.clone()),
                 working_dir: std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
+                schedule_id: None,
             }),
         )
         .await;
@@ -206,6 +207,7 @@ pub async fn reply_session_handler(
             Some(SessionConfig {
                 id: Identifier::Name(session_name.clone()),
                 working_dir: std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
+                schedule_id: None,
             }),
         )
         .await;


### PR DESCRIPTION
## Summary
- include `schedule_id` when creating `SessionConfig`

## Testing
- `cargo check --workspace --quiet` *(fails: failed to download crates)*