### PR TITLE
fix(api): handle extension removal errors

### DIFF
--- a/crates/goose-api/src/handlers.rs
+++ b/crates/goose-api/src/handlers.rs
@@ -430,9 +430,15 @@ pub async fn remove_extension_handler(
 ) -> Result<impl warp::Reply, Rejection> {
     info!("Removing extension: {}", name);
     let agent = AGENT.lock().await;
-    agent.remove_extension(&name).await;
+    let result = agent.remove_extension(&name).await;
 
-    let resp = ExtensionResponse { error: false, message: None };
+    let resp = match result {
+        Ok(_) => ExtensionResponse { error: false, message: None },
+        Err(e) => ExtensionResponse {
+            error: true,
+            message: Some(format!("Failed to remove extension, error: {:?}", e)),
+        },
+    };
     Ok(warp::reply::json(&resp))
 }
 


### PR DESCRIPTION
## Summary
- return an error message if extension removal fails in HTTP handler

## Testing
- `cargo check -p goose-api` *(fails: failed to fetch crates)*