### PR TITLE
Improve goose-api configuration

### DIFF
--- a/crates/goose-api/README.md
+++ b/crates/goose-api/README.md
@@ -28,15 +28,19 @@ cargo build --release
 
 ## Configuration
 
-Goose API supports configuration through both environment variables and a configuration file. The precedence order is:
+Goose API supports configuration via environment variables and configuration files.
+The precedence order is:
 
 1. Environment variables (highest priority)
-2. Configuration file (lower priority)
-3. Default values (lowest priority)
+2. Goose CLI configuration file (usually `~/.config/goose/config.yaml`) if it exists
+3. `config` file shipped with the crate
+4. Default values (lowest priority)
 
 ### Configuration File
 
-Create a file named `config` (with no extension) in the directory where you run the goose-api. The format can be JSON, YAML, TOML, etc. (the `config` crate will detect the format automatically).
+If no CLI configuration file is found, goose-api looks for a `config` file in its
+crate directory. This file has no extension and can be JSON, YAML, TOML, etc.
+The `config` crate will detect the format automatically.
 
 Example `config` file (YAML format):
 

--- a/crates/goose-api/config
+++ b/crates/goose-api/config
@@ -1,0 +1,8 @@
+# API server configuration
+host: 0.0.0.0
+port: 8080
+api_key: kurac
+
+# Provider configuration
+provider: ollama
+model: qwen3:8b


### PR DESCRIPTION
## Summary
- prefer the Goose CLI config when loading configuration in goose-api
- add bundled `config` file
- document CLI config precedence in goose-api README

## Testing
- `cargo test -p goose-api` *(fails: failed to download from crates.io)*