### PR TITLE
Implement session summarization endpoint

### DIFF
--- a/crates/goose-api/README.md
+++ b/crates/goose-api/README.md
@@ -236,6 +236,31 @@ By default, the server runs on `127.0.0.1:8080`. You can modify this using confi
 }
 ```
 
+### 7. Summarize Session
+
+**Endpoint**: `POST /session/summarize`
+
+**Description**: Summarizes the full conversation for a given session.
+
+**Request**:
+- Headers:
+  - Content-Type: application/json
+  - x-api-key: [your-api-key]
+- Body:
+```json
+{
+  "session_id": "<uuid>"
+}
+```
+
+**Response**:
+```json
+{
+  "message": "<summarized conversation>",
+  "status": "success"
+}
+```
+
 ## Session Management
 
 Sessions created via the API are stored in the same location as the CLI
@@ -279,6 +304,12 @@ curl -X POST http://localhost:8080/extensions/remove \
 # Get provider configuration
 curl -X GET http://localhost:8080/provider/config \
   -H "x-api-key: your_secure_api_key"
+
+# Summarize a session
+curl -X POST http://localhost:8080/session/summarize \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: your_secure_api_key" \
+  -d '{"session_id": "your-session-id"}'
 ```
 
 ### Using Python
@@ -331,6 +362,14 @@ print(response.json())
 
 # Get provider configuration
 response = requests.get(f"{API_URL}/provider/config", headers=HEADERS)
+print(response.json())
+
+# Summarize a session
+response = requests.post(
+    f"{API_URL}/session/summarize",
+    headers=HEADERS,
+    json={"session_id": "your-session-id"}
+)
 print(response.json())
 ```
 

--- a/crates/goose-api/src/routes.rs
+++ b/crates/goose-api/src/routes.rs
@@ -4,7 +4,7 @@ use tracing::{info, warn, error};
 use crate::handlers::{
     add_extension_handler, end_session_handler, get_provider_config_handler,
     list_extensions_handler, remove_extension_handler, reply_session_handler,
-    start_session_handler, with_api_key,
+    start_session_handler, summarize_session_handler, with_api_key,
 };
 use crate::config::{
     initialize_extensions, initialize_provider_config, load_configuration,
@@ -25,6 +25,13 @@ pub fn build_routes(api_key: String) -> impl Filter<Extract = impl warp::Reply, 
         .and(warp::body::json())
         .and(with_api_key(api_key.clone()))
         .and_then(reply_session_handler);
+
+    let summarize_session = warp::path("session")
+        .and(warp::path("summarize"))
+        .and(warp::post())
+        .and(warp::body::json())
+        .and(with_api_key(api_key.clone()))
+        .and_then(summarize_session_handler);
 
     let end_session = warp::path("session")
         .and(warp::path("end"))
@@ -59,6 +66,7 @@ pub fn build_routes(api_key: String) -> impl Filter<Extract = impl warp::Reply, 
 
     start_session
         .or(reply_session)
+        .or(summarize_session)
         .or(end_session)
         .or(list_extensions)
         .or(add_extension)


### PR DESCRIPTION
## Summary
- implement `summarize_session_handler`
- add `/session/summarize` route
- document API usage for new endpoint

## Testing
- `cargo test -p goose-api` *(fails: could not download crates)*