### PR TITLE
Add metrics endpoint

### DIFF
--- a/crates/goose-api/README.md
+++ b/crates/goose-api/README.md
@@ -236,6 +236,30 @@ By default, the server runs on `127.0.0.1:8080`. You can modify this using confi
 }
 ```
 
+### 7. Metrics
+
+**Endpoint**: `GET /metrics`
+
+**Description**: Returns runtime metrics about stored sessions and extensions.
+
+**Request**:
+- Headers:
+  - `x-api-key: [your-api-key]`
+
+**Response** (example):
+```json
+{
+  "session_messages": {
+    "20240605_001234": 3,
+    "20240605_010000": 5
+  },
+  "active_sessions": 2,
+  "pending_requests": {
+    "mcp_say": 0
+  }
+}
+```
+
 ## Session Management
 
 Sessions created via the API are stored in the same location as the CLI

--- a/crates/goose-api/src/routes.rs
+++ b/crates/goose-api/src/routes.rs
@@ -4,7 +4,7 @@ use tracing::{info, warn, error};
 use crate::handlers::{
     add_extension_handler, end_session_handler, get_provider_config_handler,
     list_extensions_handler, remove_extension_handler, reply_session_handler,
-    start_session_handler, with_api_key,
+    start_session_handler, metrics_handler, with_api_key,
 };
 use crate::config::{
     initialize_extensions, initialize_provider_config, load_configuration,
@@ -57,6 +57,10 @@ pub fn build_routes(api_key: String) -> impl Filter<Extract = impl warp::Reply, 
         .and(warp::get())
         .and_then(get_provider_config_handler);
 
+    let metrics = warp::path("metrics")
+        .and(warp::get())
+        .and_then(metrics_handler);
+
     start_session
         .or(reply_session)
         .or(end_session)
@@ -64,6 +68,7 @@ pub fn build_routes(api_key: String) -> impl Filter<Extract = impl warp::Reply, 
         .or(add_extension)
         .or(remove_extension)
         .or(get_provider_config)
+        .or(metrics)
 }
 
 pub async fn run_server() -> Result<(), anyhow::Error> {


### PR DESCRIPTION
## Summary
- implement `/metrics` handler and route in goose-api
- expose pending requests from transports and extension manager
- document metrics usage in goose-api README

## Testing
- `cargo check --locked --offline` *(fails: no matching package named `anyhow` found)*
- `cargo test --locked --offline` *(fails: no matching package named `anyhow` found)*